### PR TITLE
attempt fix #34

### DIFF
--- a/scripts/app.helper.js
+++ b/scripts/app.helper.js
@@ -59,7 +59,6 @@ let App = {
     // Return the owner address
     async readOwnerAddress(){
         App.contractOwner = await App.contract.owner({from: web3.eth.defaultAccount})
-        .on('error', console.error);
         return App.contractOwner;
     },
 
@@ -67,7 +66,6 @@ let App = {
     // Return the owner balance
     async readOwnerBalance(){
         let owner_balance = await App.contract.ownerBalance({from: web3.eth.defaultAccount})
-        .on('error', console.error);
         owner_balance = web3.utils.fromWei(owner_balance.toString(), "ether" );
         return owner_balance;
     },
@@ -77,7 +75,6 @@ let App = {
     // Return the state object 
     async readUniversityState(account){
         let university_state = await App.contract.universities(account, {from: web3.eth.defaultAccount})
-        .on('error', console.error);
         return university_state;
     },
 
@@ -98,7 +95,6 @@ let App = {
     // Return the transaction object
     async disableUniversity(account){
         let disable_university = await App.contract.disableUniversity(account,  {from: web3.eth.defaultAccount, gas: gasAmount})
-        .on('error', console.error);
         return disable_university;
     },
 
@@ -130,7 +126,6 @@ let App = {
     // Return the transaction object
     async readProjectState(projectHash){
             let read_project_state = await App.contract.projects(projectHash, {from: web3.eth.defaultAccount})
-            .on('error', console.error);
             return read_project_state;
     },
 


### PR DESCRIPTION
#34 resolved Travis and local build behaving the same way

Current status:

```
31 passing (4s)
  1 failing
  1) App Tests
       Calling the contract
         Has a function to let anyone donate to a univesrity and a project:
     Error: Returned error: sender doesn't have enough funds to send tx. The upfront cost is: 100060000000000000000 and the sender's account only has: 99999002480000000000
      at Object.ErrorResponse (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/web3-eth/~/web3-core-helpers/src/errors.js:29:1)
      at /home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/web3-eth/~/web3-core-requestmanager/src/index.js:140:1
      at /home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/packages/truffle-provider/wrapper.js:112:1
      at XMLHttpRequest.request.onreadystatechange (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/web3/~/web3-providers-http/src/index.js:96:1)
      at XMLHttpRequestEventTarget.dispatchEvent (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/xhr2-cookies/dist/xml-http-request-event-target.js:34:1)
      at XMLHttpRequest._setReadyState (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/xhr2-cookies/dist/xml-http-request.js:208:1)
      at XMLHttpRequest._onHttpResponseEnd (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/xhr2-cookies/dist/xml-http-request.js:318:1)
      at IncomingMessage.<anonymous> (/home/travis/.nvm/versions/node/v10.18.0/lib/node_modules/truffle/build/webpack:/~/xhr2-cookies/dist/xml-http-request.js:289:47)
      at endReadableNT (_stream_readable.js:1143:12)
      at process._tickCallback (internal/process/next_tick.js:63:19)
The command "truffle test" exited with 1.
cache.2
store build cache
Done. Your build exited with 1.
``